### PR TITLE
fix: <link rel="canonical"> conflict causing SEO issues

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -6,13 +6,15 @@ import Layout from "@/components/Modules/Layout/Layout";
 import { pageview } from "utils/google-analytics";
 import seo from "utils/seo";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import {useEffect, useState} from "react";
 
 function MyApp({ Component, pageProps }) {
   const router = useRouter();
+  const [seoData, setSeoData] = useState(seo);
 
   useEffect(() => {
     const handleRouteChange = (url) => {
+      setSeoData({...seoData, canonical: "https://robor.systems" + url});
       pageview(url);
     };
     //When the component is mounted, subscribe to router changes
@@ -28,7 +30,7 @@ function MyApp({ Component, pageProps }) {
   return (
     <ThemeProvider attribute="class">
       <Layout>
-        <DefaultSeo {...seo} />
+        <DefaultSeo {...seoData} />
         <Component {...pageProps} />
       </Layout>
     </ThemeProvider>

--- a/pages/clients/index.jsx
+++ b/pages/clients/index.jsx
@@ -22,7 +22,6 @@ const WorkPage = () => {
     <>
       <Head>
         <title>Our Clients | Robor Systems</title>
-        <link rel="canonical" href="https://robor.systems/clients"></link>
       </Head>
       <main
         ref={ref}

--- a/pages/solutions/index.jsx
+++ b/pages/solutions/index.jsx
@@ -22,7 +22,6 @@ const SolutionsPage = () => {
     <>
       <Head>
         <title>Solutions | Robor Systems</title>
-        <link rel="canonical" href="https://robor.systems/solutions"></link>
       </Head>
       <main
         ref={ref}


### PR DESCRIPTION
Seo analysis with lighthouse showed duplicate/conflicting <link rel="canonical"> tags. Fix: now this link is generated once and dynamically. Skipped the /qualityPolicy page since it doesn't have this issue. 